### PR TITLE
Hotfix for toload permission issue

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 USER="${GDB_USER:=root}"
 
+mkdir -p /repository.init
+mkdir -p /tmp/toLoad.tmp
+
 if [ "$USER" != "root" -a "$USER" != "0" ]; then
   if [ $(expr "$USER" : "^[0-9]*$") -eq 0 ]; then
     USER_PWD=$(cat /etc/passwd | grep -e "^$USER:" || true)
@@ -12,8 +15,5 @@ if [ "$USER" != "root" -a "$USER" != "0" ]; then
   fi
   set-ownership $USER
 fi
-
-mkdir -p /repository.init
-mkdir -p /tmp/graphdb/toLoad
 
 exec tini -g gosu -- $USER run-graphdb "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,4 +13,6 @@ if [ "$USER" != "root" -a "$USER" != "0" ]; then
   set-ownership $USER
 fi
 
+mkdir -p /tmp/graphdb/toLoad
+
 exec tini -g gosu -- $USER run-graphdb "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,7 @@ if [ "$USER" != "root" -a "$USER" != "0" ]; then
   set-ownership $USER
 fi
 
+mkdir -p /repository.init
 mkdir -p /tmp/graphdb/toLoad
 
 exec tini -g gosu -- $USER run-graphdb "$@"

--- a/graphdb-repository-init/repo_init.go
+++ b/graphdb-repository-init/repo_init.go
@@ -46,23 +46,13 @@ func assembleToLoadFolderPath(repositoryDirectory string) string {
 		fmt.Printf("%s Warning: Couldn't find data to load for '%s'. 'toLoad' is missing.\n",
 			LogPrefix, repositoryDirectory)
 	}
-	p := "/tmp/graphdb/toLoad"
+	p := "/tmp/toLoad.tmp"
 	err := os.MkdirAll(p, os.ModeDir)
 	if err != nil {
 		fmt.Printf("%s Warning: Couldn't create temporary folder '%s': %s\n",
 			LogPrefix, p, err.Error())
 	}
 	return p
-}
-
-// cleanTemporaryLoadFolder cleans the temporary folder, if it has been created.
-func cleanTemporaryLoadFolder(toLoadFolder string) {
-	if toLoadFolder == "/tmp/graphdb/toLoad" {
-		err := os.RemoveAll("/tmp/graphdb/toLoad")
-		if err != nil {
-			fmt.Printf("%s Warning: Couldn't delete temporary 'toLoad' folder. %s\n", LogPrefix, err.Error())
-		}
-	}
 }
 
 // InitRepository initializes the repository configured in the given directory. returns true,
@@ -95,12 +85,10 @@ func InitRepository(repositoryDirectory string) bool {
 						fmt.Printf("%s Error: Failed to write the lock for a new initialization. %s",
 							LogPrefix, err.Error())
 					}
-					cleanTemporaryLoadFolder(toLoadFolder)
 					return true
 				} else {
 					fmt.Printf("%s Error: Execution of %s command failed. %s\n", LogPrefix, PreloadTool,
 						err.Error())
-					cleanTemporaryLoadFolder(toLoadFolder)
 				}
 			} else {
 				fmt.Printf("%s Error: Could not find config.ttl for '%s'. %s\n", LogPrefix, repositoryDirectory,

--- a/set-ownership.sh
+++ b/set-ownership.sh
@@ -8,8 +8,5 @@ fi
 USER=$1
 
 chown $USER -R /opt/graphdb
-chown $USER -R /tmp/graphdb
-
-if [ -d "/repository.init" ]; then
-  chown $USER -R /repository.init || true
-fi
+chown $USER -R /tmp/graphdb || true
+chown $USER -R /repository.init --quiet || true

--- a/set-ownership.sh
+++ b/set-ownership.sh
@@ -8,5 +8,5 @@ fi
 USER=$1
 
 chown $USER -R /opt/graphdb
-chown $USER -R /tmp/graphdb || true
+chown $USER -R /tmp/toLoad.tmp || true
 chown $USER -R /repository.init --quiet || true

--- a/set-ownership.sh
+++ b/set-ownership.sh
@@ -8,6 +8,7 @@ fi
 USER=$1
 
 chown $USER -R /opt/graphdb
+chown $USER -R /tmp/graphdb
 
 if [ -d "/repository.init" ]; then
   chown $USER -R /repository.init || true


### PR DESCRIPTION
Solves the bug #6, where running a container with a non-root users fail, if a repository initialization has a configuration, but no data to load (i.e. a non-existing toLoad folder). 

The entry script creates now the temporary toLoad folder in case a repository misses it and changes its ownership accordingly.